### PR TITLE
Close #10: Scaffold Helm umbrella chart

### DIFF
--- a/charts/mcp-obs/Chart.yaml
+++ b/charts/mcp-obs/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: mcp-obs
+description: "Observability stack – MCP server plus Grafana, Loki, Prometheus, Tempo, and OpenTelemetry Collector"
+
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+# Umbrella chart: leverage upstream community charts
+
+dependencies:
+  - name: grafana
+    version: "6.*"
+    repository: "https://grafana.github.io/helm-charts"
+    condition: grafana.enabled
+
+  - name: loki
+    version: "5.*"
+    repository: "https://grafana.github.io/helm-charts"
+    condition: loki.enabled
+
+  - name: prometheus
+    version: "19.*"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus.enabled
+
+  - name: tempo
+    version: "1.*"
+    repository: "https://grafana.github.io/helm-charts"
+    condition: tempo.enabled
+
+  - name: opentelemetry-collector
+    version: "0.*"
+    repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    condition: otelCollector.enabled 

--- a/charts/mcp-obs/templates/_helpers.tpl
+++ b/charts/mcp-obs/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Common template helpers for mcp-obs chart
+*/}}
+
+{{- define "mcp-obs.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "mcp-obs.fullname" -}}
+{{ printf "%s-%s" .Release.Name (include "mcp-obs.name" .) }}
+{{- end -}}
+
+{{- define "mcp-obs.labels" -}}
+app.kubernetes.io/name: {{ include "mcp-obs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "mcp-obs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-obs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}} 

--- a/charts/mcp-obs/templates/mcp-server-deployment.yaml
+++ b/charts/mcp-obs/templates/mcp-server-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-obs.fullname" . }}-server
+  labels:
+    {{- include "mcp-obs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-obs.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mcp-server
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-obs.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp-server
+    spec:
+      containers:
+        - name: server
+          image: "{{ .Values.mcpServer.image.repository }}:{{ .Values.mcpServer.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://{{ include "mcp-obs.fullname" . }}-otel-collector:4318"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      {{- if .Values.mcpServer.persistence.enabled }}
+      volumes:
+        - name: mcp-storage
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-obs.fullname" . }}-server-pvc
+      {{- end }} 

--- a/charts/mcp-obs/templates/mcp-server-pvc.yaml
+++ b/charts/mcp-obs/templates/mcp-server-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.mcpServer.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-obs.fullname" . }}-server-pvc
+  labels:
+    {{- include "mcp-obs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.mcpServer.persistence.size }}
+{{- end }} 

--- a/charts/mcp-obs/templates/mcp-server-service.yaml
+++ b/charts/mcp-obs/templates/mcp-server-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-obs.fullname" . }}-server
+  labels:
+    {{- include "mcp-obs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-obs.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server 

--- a/charts/mcp-obs/values.yaml
+++ b/charts/mcp-obs/values.yaml
@@ -1,0 +1,49 @@
+# Default values for mcp-obs umbrella chart.
+
+# Global persistence toggle – override per sub-chart below
+persistence:
+  enabled: false
+
+# MCP Server image settings
+mcpServer:
+  image:
+    repository: "ghcr.io/your-org/mcp-server"
+    tag: "latest"
+  # Enable PVC for the server (e.g., SQLite, logs)
+  persistence:
+    enabled: false
+    size: 1Gi
+
+# Upstream charts enablement flags – default all true
+loki:
+  enabled: true
+  loki:
+    persistence:
+      enabled: false
+      size: 5Gi
+
+grafana:
+  enabled: true
+  persistence:
+    enabled: false
+    size: 1Gi
+
+prometheus:
+  enabled: true
+  server:
+    persistentVolume:
+      enabled: false
+      size: 5Gi
+
+tempo:
+  enabled: true
+  persistence:
+    enabled: false
+    size: 5Gi
+
+otelCollector:
+  enabled: true
+  mode: deployment
+  presets:
+    kubernetesAttributes: true
+    kubernetesClusterReceiver: true 

--- a/mcp-obs.yml
+++ b/mcp-obs.yml
@@ -1,0 +1,82 @@
+version: "3.9"
+
+services:
+  # MCP Application Server
+  mcp-server:
+    build:
+      context: .
+      dockerfile: Dockerfile  # TODO: Provide production-ready Dockerfile in later task
+    container_name: mcp-server
+    ports:
+      - "8000:8000"
+    environment:
+      # Point the OpenTelemetry SDK to the collector
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    depends_on:
+      - otel-collector
+
+  # OpenTelemetry Collector
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.95.0
+    container_name: otel-collector
+    command: ["--config=/etc/otelcol/config.yaml"]
+    ports:
+      - "4317:4317" # gRPC
+      - "4318:4318" # HTTP
+    volumes:
+      # Ephemeral storage for collector state (buffers, etc.)
+      - otel-data:/etc/otelcol/data
+
+  # Loki – log aggregation
+  loki:
+    image: grafana/loki:2.9.3
+    container_name: loki
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki-data:/loki
+
+  # Prometheus – metrics
+  prometheus:
+    image: prom/prometheus:v2.50.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - prom-data:/prometheus
+
+  # Tempo – traces backend
+  tempo:
+    image: grafana/tempo:2.4.1
+    container_name: tempo
+    command: ["-config.file=/etc/tempo/local-config.yaml"]
+    ports:
+      - "3200:3200"
+      - "4319:4319"  # OTLP gRPC (internal)
+    volumes:
+      - tempo-data:/var/tempo
+
+  # Grafana – dashboards UI
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - loki
+      - prometheus
+      - tempo
+
+# Named volumes – remain ephemeral unless mapped externally
+volumes:
+  otel-data:
+  loki-data:
+  prom-data:
+  tempo-data:
+  grafana-data: 


### PR DESCRIPTION
AI-generated implementation of Helm chart 'mcp-obs' including:\n\n* Chart.yaml with dependencies referencing upstream Grafana, Loki, Prometheus, Tempo, and OTel Collector charts\n* Umbrella templates for MCP server Deployment, Service, optional PVC\n* Default values.yaml with persistence toggles\n\nCloses #10.