### PR TITLE
Close #18: Add Compose mTLS sidecar and TLS wiring

### DIFF
--- a/mcp-obs.yml
+++ b/mcp-obs.yml
@@ -12,8 +12,31 @@ services:
     environment:
       # Point the OpenTelemetry SDK to the collector
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    volumes:
+      - certs:/certs:ro
+    command:
+      - uvicorn
+      - app.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --ssl-keyfile
+      - /certs/server.key
+      - --ssl-certfile
+      - /certs/server.crt
     depends_on:
+      - mcp-certgen
       - otel-collector
+
+  # Sidecar generating TLS certificates (self-signed)
+  mcp-certgen:
+    build:
+      context: ./scripts/certgen
+    container_name: mcp-certgen
+    volumes:
+      - certs:/certs
+    restart: on-failure
 
   # OpenTelemetry Collector
   otel-collector:
@@ -79,4 +102,5 @@ volumes:
   loki-data:
   prom-data:
   tempo-data:
-  grafana-data: 
+  grafana-data:
+  certs: 

--- a/scripts/certgen/Dockerfile
+++ b/scripts/certgen/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache openssl
+
+# Copy entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+VOLUME ["/certs"]
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"] 

--- a/scripts/certgen/entrypoint.sh
+++ b/scripts/certgen/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+CERT_DIR="${CERT_DIR:-/certs}"
+mkdir -p "$CERT_DIR"
+
+CA_KEY="$CERT_DIR/ca.key"
+CA_CERT="$CERT_DIR/ca.crt"
+SERVER_KEY="$CERT_DIR/server.key"
+SERVER_CSR="$CERT_DIR/server.csr"
+SERVER_CERT="$CERT_DIR/server.crt"
+
+# Generate CA if missing
+if [ ! -f "$CA_KEY" ] || [ ! -f "$CA_CERT" ]; then
+    echo "[*] Generating new CA certificate"
+    openssl req -x509 -nodes -new -newkey rsa:2048 -days 365 \
+        -subj "/CN=mcp-ca" \
+        -keyout "$CA_KEY" -out "$CA_CERT"
+fi
+
+# Always (re)generate server certificate for now; rotate every start
+echo "[*] Generating server certificate signed by CA"
+openssl req -new -nodes -newkey rsa:2048 \
+    -subj "/CN=mcp-server" \
+    -keyout "$SERVER_KEY" -out "$SERVER_CSR"
+
+openssl x509 -req -in "$SERVER_CSR" -CA "$CA_CERT" -CAkey "$CA_KEY" \
+    -CAcreateserial -out "$SERVER_CERT" -days 90
+
+rm -f "$SERVER_CSR" "$CERT_DIR/ca.srl" 2>/dev/null || true
+
+ls -l "$CERT_DIR"
+
+echo "[*] Certificate generation complete. Sleeping to keep sidecar alive."
+exec sleep infinity 


### PR DESCRIPTION
Implements self-signed certificate generator sidecar (scripts/certgen) and wires TLS into mcp-server via shared cert volume.\n\nFast follow: Helm cert-manager (#19) and TLS tests (#20).