### PR TITLE
Close #24: Implement /logs/errors endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then visit `http://localhost:8000/health` to verify the service is running.
 | Path | Method | Description |
 |------|--------|-------------|
 | `/health` | GET | Returns `{"status": "ok"}` when the service is healthy. |
+| `/logs/errors` | GET | Fetches the last N error log lines from Loki (`limit` query param, default 100). |
 
 ## Tests
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, status
+from fastapi import Depends, FastAPI, status, Query, HTTPException
 
 from app.security import verify_bearer_token
 
@@ -13,6 +13,82 @@ app = FastAPI(title="MCP Observability API")
 async def health() -> dict[str, str]:
     """Simple health check endpoint."""
     return {"status": "ok"}
+
+
+# --- Logs ------------------------------------------------------------------
+
+import os
+from typing import Any, List
+
+import httpx
+
+
+LOKI_BASE_URL: str = os.getenv("LOKI_BASE_URL", "http://loki:3100")
+
+
+async def _fetch_error_logs(limit: int) -> List[str]:
+    """Fetch the last *limit* error log lines from Loki.
+
+    The function performs a GET request to Loki's *instant* query API using a
+    label matcher that filters for logs with level="error". Only the log line
+    strings are returned, newest first.
+    """
+
+    # Loki instant query endpoint; we rely on the default tenant and time=now.
+    url = f"{LOKI_BASE_URL.rstrip('/')}/loki/api/v1/query"
+    params = {
+        "query": '{level="error"}',  # simple filter; adjust if needed
+        "limit": str(limit),
+    }
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        try:
+            response = await client.get(url, params=params)
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to contact Loki: {exc}",
+            ) from exc
+
+    if response.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Loki returned {response.status_code}",
+        )
+
+    data: Any = response.json()
+    # Expected structure: {"data": {"result": [ {"values": [[ts, line], ...]} ] } }
+    try:
+        results = data["data"]["result"]
+    except (KeyError, TypeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Unexpected Loki response format",
+        ) from exc
+
+    lines: List[str] = []
+    for stream in results:
+        for _ts, line in stream.get("values", []):
+            lines.append(line)
+
+    # Loki returns newest first within each stream; we preserve order as‐is.
+    return lines[:limit]
+
+
+@app.get(
+    "/logs/errors",
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(verify_bearer_token)],
+)
+async def logs_errors(limit: int = Query(100, ge=1, le=1000)) -> dict[str, list[str]]:
+    """Return the last *limit* error log lines from Loki.
+
+    The endpoint proxies a query to the Loki HTTP API, returning only the raw
+    log lines so that API consumers do not need to know Loki's schema.
+    """
+
+    logs = await _fetch_error_logs(limit)
+    return {"logs": logs}
 
 
 def run() -> None:  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ packages = [{ include = "app" }]
 python = "^3.12"
 fastapi = "^0.110.2"
 uvicorn = { extras = ["standard"], version = "^0.29.0" }
+httpx = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"
 pytest-asyncio = "^0.23.2"
-httpx = "^0.27.0"
 black = "^24.4.2"
 isort = "^5.13.2"
 mypy = "^1.8.0"

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,81 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app, _fetch_error_logs
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, json_data: dict):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+class DummyClient:
+    """Minimal async context-manager mimicking httpx.AsyncClient."""
+
+    def __init__(self, *, status_code: int = 200, json_data: dict | None = None):
+        self._response = DummyResponse(status_code, json_data or {})
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False  # propagate exceptions
+
+    async def get(self, url: str, params=None):
+        # ignore url/params validation for brevity
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_fetch_error_logs_success(monkeypatch: pytest.MonkeyPatch):
+    """Helper should return parsed log lines from Loki JSON payload."""
+
+    fake_json = {
+        "data": {
+            "result": [
+                {
+                    "values": [
+                        ["1718486400000000", "first error"],
+                        ["1718486400000001", "second error"],
+                    ]
+                }
+            ]
+        }
+    }
+
+    monkeypatch.setattr("app.main.httpx.AsyncClient", lambda *a, **k: DummyClient(json_data=fake_json))
+
+    lines = await _fetch_error_logs(10)
+    assert lines == ["first error", "second error"]
+
+
+@pytest.mark.asyncio
+async def test_logs_errors_endpoint(monkeypatch: pytest.MonkeyPatch):
+    """Endpoint returns logs array when provided valid token."""
+
+    fake_json = {
+        "data": {
+            "result": [
+                {"values": [["123", "err one"], ["124", "err two"]]}
+            ]
+        }
+    }
+
+    monkeypatch.setenv("MCP_TOKEN", "testtoken")
+    monkeypatch.setattr("app.main.httpx.AsyncClient", lambda *a, **k: DummyClient(json_data=fake_json))
+
+    transport = ASGITransport(app=app, raise_app_exceptions=True)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get(
+            "/logs/errors?limit=2",
+            headers={"Authorization": "Bearer testtoken"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"logs": ["err one", "err two"]} 


### PR DESCRIPTION
Adds new endpoint that queries Loki for error logs.\n\n• Implements async helper _fetch_error_logs via httpx.\n• Adds runtime dependency on httpx.\n• Includes unit tests mocking Loki responses.\n• Updates docs.\n