### PR TITLE
Close #34: Add Grafana provisioning YAML & Compose mounts

### DIFF
--- a/grafana/provisioning/dashboards.yaml
+++ b/grafana/provisioning/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: false
+    updateIntervalSeconds: 600
+    options:
+      path: /var/lib/grafana/dashboards 

--- a/mcp-obs.yml
+++ b/mcp-obs.yml
@@ -91,6 +91,9 @@ services:
       - "3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
+      # Mount provisioning configuration and dashboards JSON from repo
+      - ./grafana/provisioning:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - loki
       - prometheus


### PR DESCRIPTION
Adds dashboard provider configuration under grafana/provisioning and mounts it plus dashboard JSON into the Grafana container.\n\nThis enables automatic loading of any JSON files placed in grafana/dashboards. Helm support will be tackled next via a chart patch.\n