### PR TITLE
CI: ignore mcp-certgen in drift check & fix tests

### DIFF
--- a/scripts/ci/check_drift.py
+++ b/scripts/ci/check_drift.py
@@ -26,6 +26,8 @@ compose_services: set[str] = set()
 with COMPOSE_PATH.open() as f:
     compose_yaml = yaml.safe_load(f)
     compose_services = set(compose_yaml.get("services", {}).keys())
+    # Exclude compose-only helper service (cert-manager handles this in Helm)
+    compose_services.discard("mcp-certgen")
 
 helm_components: set[str] = set()
 with CHART_PATH.open() as f:

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -53,8 +53,14 @@ async def test_trace_endpoints(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MCP_TOKEN", "tok")
 
     # Patch helper functions instead of HTTP layer for simplicity
-    monkeypatch.setattr("app.main._fetch_trace_json", lambda trace_id: fake_trace)
-    monkeypatch.setattr("app.main._fetch_trace_logs", lambda trace_id, limit: ["l1"])
+    async def fake_json_fn(trace_id):
+        return fake_trace
+
+    async def fake_logs_fn(trace_id, limit):
+        return ["l1"]
+
+    monkeypatch.setattr("app.main._fetch_trace_json", fake_json_fn)
+    monkeypatch.setattr("app.main._fetch_trace_logs", fake_logs_fn)
 
     transport = ASGITransport(app=app, raise_app_exceptions=True)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:


### PR DESCRIPTION
Adjust drift checker to exclude compose-only mcp-certgen service and fix async monkeypatch in trace tests. Should make compose-vs-helm-drift workflow green.